### PR TITLE
Added warning to sql file to ensure inserts are commented before running tests

### DIFF
--- a/twitter-schema.sql
+++ b/twitter-schema.sql
@@ -28,6 +28,9 @@ CREATE TABLE tweet (
   )
 );
 
+--WARNING: THE BELOW LINES MUST BE COMMENTED BEFORE YOU RUN YOUR TESTS
+--         FAILURE TO DO SO WILL CAUSE YOUR TESTS TO FAIL
+
 --INSERT INTO "user" ("id", "username", "password", "birth_date") VALUES (10, "martinzugnoni", "81dc9bdb52d04dc20036dbd8313ed055", "2016-01-26");
 --INSERT INTO "user" ("id", "username", "password", "birth_date") VALUES (11, "ivanzugnoni", "81dc9bdb52d04dc20036dbd8313ed055", "2016-07-06");
 --INSERT INTO "tweet" ("user_id", "content") VALUES (10, "Hello World!");


### PR DESCRIPTION
Noticed multiple students had uncommented the insert statements and then left them uncommented when running the tests. This caused mismatches in the data when getting to the `delete` tests as tweet 1 no longer belonged to user 1. Placed warning so that students make sure that if they uncomment those lines they re-comment them before running tests.